### PR TITLE
Add examples and update docs

### DIFF
--- a/examples/tiles/tileset-bbox.json
+++ b/examples/tiles/tileset-bbox.json
@@ -1,0 +1,32 @@
+{
+  "title": "OpenStreetMap",
+  "dataType": "map",
+  "tileMatrixSetURI": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "crs": "http://www.opengis.net/def/crs/EPSG/0/3857",
+  "boundingBox": {
+    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "lowerLeft": [
+      -180,
+      -90
+    ],
+    "upperRight": [
+      180,
+      90
+    ]
+  },
+  "links": [
+    {
+      "href": "https://tile.openstreetmap.org/{tileMatrix}/{tileCol}/{tileRow}.png",
+      "rel": "item",
+      "type": "image/png",
+      "title": "Tile URL Template",
+      "templated": true
+    },
+    {
+      "href": "https://ogc-tiles.xyz/tileMatrixSets/WebMercatorQuad",
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
+      "type": "application/json",
+      "title": "Tiling Scheme"
+    }
+  ]
+}

--- a/examples/tiles/tileset-limits.json
+++ b/examples/tiles/tileset-limits.json
@@ -1,0 +1,163 @@
+{
+  "title": "OpenStreetMap",
+  "dataType": "map",
+  "tileMatrixSetURI": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "tileMatrixSetLimits": [
+    {
+      "tileMatrix": "0",
+      "minTileRow": 0,
+      "maxTileRow": 0,
+      "minTileCol": 0,
+      "maxTileCol": 0
+    },
+    {
+      "tileMatrix": "1",
+      "minTileRow": 0,
+      "maxTileRow": 1,
+      "minTileCol": 0,
+      "maxTileCol": 1
+    },
+    {
+      "tileMatrix": "2",
+      "minTileRow": 0,
+      "maxTileRow": 3,
+      "minTileCol": 0,
+      "maxTileCol": 3
+    },
+    {
+      "tileMatrix": "3",
+      "minTileRow": 0,
+      "maxTileRow": 7,
+      "minTileCol": 0,
+      "maxTileCol": 7
+    },
+    {
+      "tileMatrix": "4",
+      "minTileRow": 0,
+      "maxTileRow": 15,
+      "minTileCol": 0,
+      "maxTileCol": 15
+    },
+    {
+      "tileMatrix": "5",
+      "minTileRow": 0,
+      "maxTileRow": 31,
+      "minTileCol": 0,
+      "maxTileCol": 31
+    },
+    {
+      "tileMatrix": "6",
+      "minTileRow": 0,
+      "maxTileRow": 63,
+      "minTileCol": 0,
+      "maxTileCol": 63
+    },
+    {
+      "tileMatrix": "7",
+      "minTileRow": 0,
+      "maxTileRow": 127,
+      "minTileCol": 0,
+      "maxTileCol": 127
+    },
+    {
+      "tileMatrix": "8",
+      "minTileRow": 0,
+      "maxTileRow": 255,
+      "minTileCol": 0,
+      "maxTileCol": 255
+    },
+    {
+      "tileMatrix": "9",
+      "minTileRow": 0,
+      "maxTileRow": 511,
+      "minTileCol": 0,
+      "maxTileCol": 511
+    },
+    {
+      "tileMatrix": "10",
+      "minTileRow": 0,
+      "maxTileRow": 1023,
+      "minTileCol": 0,
+      "maxTileCol": 1023
+    },
+    {
+      "tileMatrix": "11",
+      "minTileRow": 0,
+      "maxTileRow": 2047,
+      "minTileCol": 0,
+      "maxTileCol": 2047
+    },
+    {
+      "tileMatrix": "12",
+      "minTileRow": 0,
+      "maxTileRow": 4095,
+      "minTileCol": 0,
+      "maxTileCol": 4095
+    },
+    {
+      "tileMatrix": "13",
+      "minTileRow": 0,
+      "maxTileRow": 8191,
+      "minTileCol": 0,
+      "maxTileCol": 8191
+    },
+    {
+      "tileMatrix": "14",
+      "minTileRow": 0,
+      "maxTileRow": 16383,
+      "minTileCol": 0,
+      "maxTileCol": 16383
+    },
+    {
+      "tileMatrix": "15",
+      "minTileRow": 0,
+      "maxTileRow": 32767,
+      "minTileCol": 0,
+      "maxTileCol": 32767
+    },
+    {
+      "tileMatrix": "16",
+      "minTileRow": 0,
+      "maxTileRow": 65535,
+      "minTileCol": 0,
+      "maxTileCol": 65535
+    },
+    {
+      "tileMatrix": "17",
+      "minTileRow": 0,
+      "maxTileRow": 131071,
+      "minTileCol": 0,
+      "maxTileCol": 131071
+    },
+    {
+      "tileMatrix": "18",
+      "minTileRow": 0,
+      "maxTileRow": 262143,
+      "minTileCol": 0,
+      "maxTileCol": 262143
+    },
+    {
+      "tileMatrix": "19",
+      "minTileRow": 0,
+      "maxTileRow": 524287,
+      "minTileCol": 0,
+      "maxTileCol": 524287
+    }
+  ],
+  "crs": "http://www.opengis.net/def/crs/EPSG/0/3857",
+  "links": [
+    {
+      "href": "https://tile.openstreetmap.org/{tileMatrix}/{tileCol}/{tileRow}.png",
+      "rel": "item",
+      "type": "image/png",
+      "title": "Tile URL Template",
+      "templated": true
+    },
+    {
+      "href": "https://ogc-tiles.xyz/tileMatrixSets/WebMercatorQuad",
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
+      "type": "application/json",
+      "title": "Tiling Scheme"
+    }
+  ]
+}

--- a/examples/tiles/tileset-minimal.json
+++ b/examples/tiles/tileset-minimal.json
@@ -1,0 +1,21 @@
+{
+  "title": "OpenStreetMap",
+  "dataType": "map",
+  "tileMatrixSetURI": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "crs": "http://www.opengis.net/def/crs/EPSG/0/3857",
+  "links": [
+    {
+      "href": "https://tile.openstreetmap.org/{tileMatrix}/{tileCol}/{tileRow}.png",
+      "rel": "item",
+      "type": "image/png",
+      "title": "Tile URL Template",
+      "templated": true
+    },
+    {
+      "href": "https://ogc-tiles.xyz/tileMatrixSets/WebMercatorQuad",
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
+      "type": "application/json",
+      "title": "Tiling Scheme"
+    }
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,16 @@
 
 The go-ogc module provides Go packages for working with OGC APIs.
 
-## The api package
+[![Go Reference](https://pkg.go.dev/badge/github.com/planetlabs/go-ogc.svg)](https://pkg.go.dev/github.com/planetlabs/go-ogc)
+![Tests](https://github.com/planetlabs/go-ogc/actions/workflows/test.yml/badge.svg)
+
+This repository contains the source for a set of [Golang packages](https://pkg.go.dev/github.com/planetlabs/go-ogc), an `xyz2ogc` command line utility, and examples of OGC API metadata documents.  See below for additional documentation on each of these.
+
+## Go packages
+
+See the [package documentation]((https://pkg.go.dev/github.com/planetlabs/go-ogc)) for a complete reference.  Below is a summary of each of the packages.
+
+### The api package
 
 The `api` package provides structs for implementing the following standards:
 
@@ -10,13 +19,13 @@ The `api` package provides structs for implementing the following standards:
  * [OGC API – Tiles](https://ogcapi.ogc.org/tiles/)
  * [OGC API – Features](https://ogcapi.ogc.org/features/)
 
-## The filter package
+### The filter package
 
 The `filter` package provides structs for encoding and decoding CQL2 filters as JSON.
 
-## xyz2ogc
+## The xyz2ogc command line utility
 
-Generate [OGC API – Tiles](https://ogcapi.ogc.org/tiles/) metadata from exiting XYZ tilesets.
+The `xyz2ogc` command line utility can be used to generate [OGC API – Tiles](https://ogcapi.ogc.org/tiles/) metadata from exiting XYZ tilesets.
 
 ### Use
 
@@ -148,3 +157,7 @@ The `Extent` field allows limiting the extent of the tileset.  The extent is des
 URL = "https://example.com/limited-extent/{z}/{x}/{y}.png"
 Extent = [-120, 40, -110, 50]
 ```
+
+## OGC – API examples
+
+See the [examples directory](./examples/) for example metadata documents for various OGC API standards.


### PR DESCRIPTION
This adds an examples directory with example tileset metadata (and a place for additional OGC API example metadata documents).