### PR TITLE
Add support for additional properties in links

### DIFF
--- a/api/common_test.go
+++ b/api/common_test.go
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2023 Planet Labs PBC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/planetlabs/go-ogc/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkMarshal(t *testing.T) {
+	cases := []struct {
+		name     string
+		link     *api.Link
+		expected string
+	}{
+		{
+			name: "basic",
+			link: &api.Link{
+				Href: "http://example.com/resource.json",
+				Rel:  "self",
+				Type: "application/json",
+			},
+			expected: `{
+				"href": "http://example.com/resource.json",
+				"rel": "self",
+				"type": "application/json"
+			}`,
+		},
+		{
+			name: "additional fields",
+			link: &api.Link{
+				Href: "http://example.com/resource.json",
+				Rel:  "self",
+				Type: "application/json",
+				AdditionalFields: map[string]interface{}{
+					"one": "foo",
+					"two": "bar",
+				},
+			},
+			expected: `{
+				"href": "http://example.com/resource.json",
+				"rel": "self",
+				"type": "application/json",
+				"one": "foo",
+				"two": "bar"
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.link)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.expected, string(data))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/getkin/kin-openapi v0.116.0
 	github.com/go-playground/validator/v10 v10.13.0
 	github.com/labstack/echo/v4 v4.10.2
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=


### PR DESCRIPTION
This adds an `AdditionalFields` field to the `Link` struct for serializing additional link properties in JSON.