### PR TITLE
Updates in to the latest spec changes

### DIFF
--- a/filter/array_test.go
+++ b/filter/array_test.go
@@ -92,11 +92,18 @@ func TestArrayComparison(t *testing.T) {
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.NoError(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			v := map[string]any{}
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.NoError(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/boolean_test.go
+++ b/filter/boolean_test.go
@@ -43,11 +43,18 @@ func TestBoolean(t *testing.T) {
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.Nil(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			var v bool
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.Nil(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/character.go
+++ b/filter/character.go
@@ -16,7 +16,11 @@ package filter
 
 import (
 	"encoding/json"
-	"fmt"
+)
+
+const (
+	caseInsensitiveOp   = "casei"
+	accentInsensitiveOp = "accenti"
 )
 
 type CharacterExpression interface {
@@ -46,19 +50,12 @@ func (*CaseInsensitive) characterExpression() {}
 func (*CaseInsensitive) patternExpression()   {}
 
 func (e *CaseInsensitive) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]CharacterExpression{"casei": e.Value})
-}
+	m := map[string]any{
+		"op":   "casei",
+		"args": []CharacterExpression{e.Value},
+	}
 
-func decodeCaseInsensitive(value any) (*CaseInsensitive, error) {
-	v, err := decodeExpression(value)
-	if err != nil {
-		return nil, fmt.Errorf("trouble decoding casei expression: %w", err)
-	}
-	c, ok := v.(CharacterExpression)
-	if !ok {
-		return nil, fmt.Errorf("expected character expression in casei, got %v", v)
-	}
-	return &CaseInsensitive{Value: c}, nil
+	return json.Marshal(m)
 }
 
 type AccentInsensitive struct {
@@ -78,7 +75,12 @@ func (*AccentInsensitive) characterExpression() {}
 func (*AccentInsensitive) patternExpression()   {}
 
 func (e *AccentInsensitive) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]CharacterExpression{"accenti": e.Value})
+	m := map[string]any{
+		"op":   "accenti",
+		"args": []CharacterExpression{e.Value},
+	}
+
+	return json.Marshal(m)
 }
 
 type String struct {
@@ -101,16 +103,4 @@ func (*String) arrayItemExpression() {}
 
 func (e *String) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.Value)
-}
-
-func decodeAccentInsensitive(value any) (*AccentInsensitive, error) {
-	v, err := decodeExpression(value)
-	if err != nil {
-		return nil, fmt.Errorf("trouble decoding accenti expression: %w", err)
-	}
-	c, ok := v.(CharacterExpression)
-	if !ok {
-		return nil, fmt.Errorf("expected character expression in accenti, got %v", v)
-	}
-	return &AccentInsensitive{Value: c}, nil
 }

--- a/filter/character_test.go
+++ b/filter/character_test.go
@@ -52,7 +52,7 @@ func TestCharacter(t *testing.T) {
 			},
 			data: `{
 				"op": "=",
-				"args": [{"property": "soup"}, {"casei": "chicken"}]
+				"args": [{"property": "soup"}, {"op": "casei", "args": ["chicken"]}]
 			}`,
 		},
 		{
@@ -65,16 +65,23 @@ func TestCharacter(t *testing.T) {
 			},
 			data: `{
 				"op": "=",
-				"args": [{"property": "soup"}, {"accenti": "Chícken"}]
+				"args": [{"property": "soup"}, {"op": "accenti", "args": ["Chícken"]}]
 			}`,
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.Nil(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			v := map[string]any{}
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.Nil(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/comparison_test.go
+++ b/filter/comparison_test.go
@@ -129,7 +129,7 @@ func TestComparison(t *testing.T) {
 			},
 			data: `{
 				"op": "like",
-				"args": [{"property": "name"}, {"casei": "park"}]
+				"args": [{"property": "name"}, {"op": "casei", "args": ["park"]}]
 			}`,
 		},
 		{
@@ -141,7 +141,7 @@ func TestComparison(t *testing.T) {
 			},
 			data: `{
 				"op": "like",
-				"args": [{"property": "name"}, {"accenti": "Noël"}]
+				"args": [{"property": "name"}, {"op": "accenti", "args": ["Noël"]}]
 			}`,
 		},
 		{
@@ -183,11 +183,18 @@ func TestComparison(t *testing.T) {
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.NoError(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			v := map[string]any{}
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.NoError(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/expression.go
+++ b/filter/expression.go
@@ -48,14 +48,6 @@ func decodeExpression(value any) (Expression, error) {
 	case []any:
 		return decodeArray(v)
 	case map[string]any:
-		if casei, ok := v["casei"]; ok {
-			return decodeCaseInsensitive(casei)
-		}
-
-		if accenti, ok := v["accenti"]; ok {
-			return decodeAccentInsensitive(accenti)
-		}
-
 		if dateString, ok := v["date"].(string); ok {
 			return decodeDate(dateString)
 		}
@@ -89,10 +81,6 @@ func decodeExpression(value any) (Expression, error) {
 				return nil, fmt.Errorf("expected args in %q op", opName)
 			}
 			return decodeOp(opName, args)
-		}
-
-		if function, ok := v["function"].(map[string]any); ok {
-			return decodeFunction(function)
 		}
 	}
 

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -1,0 +1,19 @@
+package filter_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func getSchema(t *testing.T) *jsonschema.Schema {
+	schemaData, err := os.ReadFile("testdata/schema/cql2.json")
+	require.NoError(t, err)
+
+	schema, err := jsonschema.CompileString("cql2.json", string(schemaData))
+	require.NoError(t, err)
+
+	return schema
+}

--- a/filter/function.go
+++ b/filter/function.go
@@ -16,13 +16,11 @@ package filter
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 )
 
 type Function struct {
-	Name string
-	Args []Expression
+	Op   string       `json:"op"`
+	Args []Expression `json:"args"`
 }
 
 var (
@@ -47,37 +45,11 @@ func (*Function) temporalExpression()  {}
 
 func (e *Function) MarshalJSON() ([]byte, error) {
 	f := map[string]any{
-		"name": e.Name,
+		"op":   e.Op,
+		"args": e.Args,
 	}
-	if len(e.Args) > 0 {
-		f["args"] = e.Args
+	if e.Args == nil {
+		f["args"] = []Expression{}
 	}
-	return json.Marshal(map[string]any{"function": f})
-}
-
-func decodeFunction(function map[string]any) (*Function, error) {
-	name, ok := function["name"].(string)
-	if !ok {
-		return nil, errors.New("missing function name")
-	}
-
-	argsValue, ok := function["args"]
-	if !ok {
-		return &Function{Name: name}, nil
-	}
-
-	argsSlice, ok := argsValue.([]any)
-	if !ok {
-		return nil, errors.New("expected function args to be an array")
-	}
-
-	args := make([]Expression, len(argsSlice))
-	for i, arg := range argsSlice {
-		argument, err := decodeExpression(arg)
-		if err != nil {
-			return nil, fmt.Errorf("trouble parsing function argument %d: %w", i, err)
-		}
-		args[i] = argument
-	}
-	return &Function{Name: name, Args: args}, nil
+	return json.Marshal(f)
 }

--- a/filter/function_test.go
+++ b/filter/function_test.go
@@ -34,7 +34,7 @@ func TestFunction(t *testing.T) {
 				Expression: &filter.Comparison{
 					Name: filter.Equals,
 					Left: &filter.Function{
-						Name: "testing",
+						Op: "testing",
 						Args: []filter.Expression{
 							&filter.Number{1},
 							&filter.Number{2},
@@ -46,29 +46,36 @@ func TestFunction(t *testing.T) {
 			},
 			data: `{
 				"op": "=",
-				"args": [{"function": {"name": "testing", "args": [1, 2, 3]}}, true]
+				"args": [{"op": "testing", "args": [1, 2, 3]}, true]
 			}`,
 		},
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Comparison{
 					Name:  filter.Equals,
-					Left:  &filter.Function{Name: "agreeable"},
+					Left:  &filter.Function{Op: "agreeable"},
 					Right: &filter.Boolean{false},
 				},
 			},
 			data: `{
 				"op": "=",
-				"args": [{"function": {"name": "agreeable"}}, false]
+				"args": [{"op": "agreeable", "args": []}, false]
 			}`,
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.Nil(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			v := map[string]any{}
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.Nil(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/logical_test.go
+++ b/filter/logical_test.go
@@ -95,11 +95,18 @@ func TestLogical(t *testing.T) {
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.Nil(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			v := map[string]any{}
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.Nil(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/numeric_test.go
+++ b/filter/numeric_test.go
@@ -44,11 +44,18 @@ func TestNumeric(t *testing.T) {
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.Nil(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			v := map[string]any{}
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.Nil(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/property_test.go
+++ b/filter/property_test.go
@@ -44,11 +44,18 @@ func TestProperty(t *testing.T) {
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.NoError(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			v := map[string]any{}
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.NoError(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/spatial_test.go
+++ b/filter/spatial_test.go
@@ -159,11 +159,18 @@ func TestSpatial(t *testing.T) {
 		},
 	}
 
+	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			data, err := json.Marshal(c.filter)
 			require.NoError(t, err)
 			assert.JSONEq(t, c.data, string(data))
+
+			v := map[string]any{}
+			require.NoError(t, json.Unmarshal(data, &v))
+			if err := schema.Validate(v); err != nil {
+				t.Errorf("failed to validate\n%#v", err)
+			}
 
 			filter := &filter.Filter{}
 			require.NoError(t, json.Unmarshal([]byte(c.data), filter))

--- a/filter/temporal.go
+++ b/filter/temporal.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -124,6 +125,13 @@ func decodeTimestamp(value string) (*Timestamp, error) {
 	return &Timestamp{Value: timestamp}, nil
 }
 
+func decodeDateOrTimestamp(value string) (InstantExpression, error) {
+	if strings.Contains(value, "T") {
+		return decodeTimestamp(value)
+	}
+	return decodeDate(value)
+}
+
 type Interval struct {
 	Start InstantExpression
 	End   InstantExpression
@@ -143,12 +151,26 @@ func (e *Interval) MarshalJSON() ([]byte, error) {
 	if e.Start == nil {
 		items[0] = ".."
 	} else {
-		items[0] = e.Start
+		switch t := e.Start.(type) {
+		case *Date:
+			items[0] = t.Value.Format(time.DateOnly)
+		case *Timestamp:
+			items[0] = t.Value
+		default:
+			items[0] = e.Start
+		}
 	}
 	if e.End == nil {
 		items[1] = ".."
 	} else {
-		items[1] = e.End
+		switch t := e.End.(type) {
+		case *Date:
+			items[1] = t.Value.Format(time.DateOnly)
+		case *Timestamp:
+			items[1] = t.Value
+		default:
+			items[1] = e.End
+		}
 	}
 	return json.Marshal(map[string]any{"interval": items})
 }
@@ -168,12 +190,12 @@ func decodeInterval(values []any) (*Interval, error) {
 	switch s := startValue.(type) {
 	case *String:
 		if s.Value != nilInstant {
-			return nil, fmt.Errorf("expected date or timestamp expression, got %s", s.Value)
+			value, err := decodeDateOrTimestamp(s.Value)
+			if err != nil {
+				return nil, fmt.Errorf("expected date or timestamp expression, got %s", s.Value)
+			}
+			start = value
 		}
-	case *Date:
-		start = s
-	case *Timestamp:
-		start = s
 	case *Property:
 		start = s
 	case *Function:
@@ -190,12 +212,12 @@ func decodeInterval(values []any) (*Interval, error) {
 	switch s := endValue.(type) {
 	case *String:
 		if s.Value != nilInstant {
-			return nil, fmt.Errorf("expected date or timestamp expression, got %s", s.Value)
+			value, err := decodeDateOrTimestamp(s.Value)
+			if err != nil {
+				return nil, fmt.Errorf("expected date or timestamp expression, got %s", s.Value)
+			}
+			end = value
 		}
-	case *Date:
-		end = s
-	case *Timestamp:
-		end = s
 	case *Property:
 		end = s
 	case *Function:

--- a/filter/testdata/schema/cql2.json
+++ b/filter/testdata/schema/cql2.json
@@ -1,0 +1,619 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$dynamicAnchor": "cql2expression",
+  "oneOf": [
+    {"$ref": "#/$defs/andOrExpression"    },
+    {"$ref": "#/$defs/notExpression"      },
+    {"$ref": "#/$defs/comparisonPredicate"},
+    {"$ref": "#/$defs/spatialPredicate"   },
+    {"$ref": "#/$defs/temporalPredicate"  },
+    {"$ref": "#/$defs/arrayPredicate"     },
+    {"$ref": "#/$defs/functionRef"        },
+    {"type": "boolean"                    }
+  ],
+  "$defs": {
+    "andOrExpression": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": { "type": "string", "enum": ["and", "or"] },
+        "args": {
+          "type": "array",
+          "minItems": 2,
+          "items": {"$dynamicRef": "#cql2expression"}
+        }
+      }
+    },
+    "notExpression": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": { "type": "string", "enum": ["not"] },
+        "args": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {"$dynamicRef": "#cql2expression"}
+        }
+      }
+    },
+    "comparisonPredicate": {
+      "oneOf": [
+        {"$ref": "#/$defs/binaryComparisonPredicate"},
+        {"$ref": "#/$defs/isLikePredicate"          },
+        {"$ref": "#/$defs/isBetweenPredicate"       },
+        {"$ref": "#/$defs/isInListPredicate"        },
+        {"$ref": "#/$defs/isNullPredicate"          }
+      ]
+    },
+    "binaryComparisonPredicate": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": { "type": "string", "enum": ["=", "<>", "<", ">", "<=", ">="] },
+        "args": {"$ref": "#/$defs/scalarOperands"}
+      }
+    },
+    "scalarOperands": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {"$ref": "#/$defs/scalarExpression"}
+    },
+    "scalarExpression": {
+      "oneOf": [
+        {"$ref": "#/$defs/characterExpression"},
+        {"$ref": "#/$defs/numericExpression"}  ,
+        {"type": "boolean"}  ,
+        {"$ref": "#/$defs/instantInstance"}    ,
+        {"$ref": "#/$defs/functionRef"},
+        {"$ref": "#/$defs/propertyRef"}
+      ]
+    },
+    "isLikePredicate": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op"  : { "type": "string", "enum": ["like"] },
+        "args": {"$ref": "#/$defs/isLikeOperands"}
+      }
+    },
+    "isLikeOperands": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        {
+          "oneOf": [
+            {"$ref": "#/$defs/characterExpression"},
+            {"$ref": "#/$defs/propertyRef"        },
+            {"$ref": "#/$defs/functionRef"        }
+          ]
+        },
+        {"$ref": "#/$defs/patternExpression"}
+      ]
+    },
+    "patternExpression": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["op", "args"],
+          "properties": {
+            "op": { "type": "string", "enum": ["casei"] },
+            "args": {
+              "type": "array",
+              "items": {"$ref": "#/$defs/patternExpression"},
+              "minItems": 1,
+              "maxItems": 1
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["op", "args"],
+          "properties": {
+            "op": { "type": "string", "enum": ["accenti"] },
+            "args": {
+              "type": "array",
+              "items": {"$ref": "#/$defs/patternExpression"},
+              "minItems": 1,
+              "maxItems": 1
+            }
+          }
+        },
+        {"type": "string"}
+      ]
+    },
+    "isBetweenPredicate": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op"  : { "type": "string", "enum": ["between"] },
+        "args": {"$ref": "#/$defs/isBetweenOperands"}
+      }
+    },
+    "isBetweenOperands": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/numericExpression"},
+          {"$ref": "#/$defs/propertyRef"      },
+          {"$ref": "#/$defs/functionRef"      }
+        ]
+      }
+    },
+    "numericExpression": {
+      "oneOf": [ {"$ref": "#/$defs/arithmeticExpression"}, {"type": "number"} ]
+    },
+    "isInListPredicate": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op"  : { "type": "string", "enum": ["in"] },
+        "args": {"$ref": "#/$defs/inListOperands"}
+      }
+    },
+    "inListOperands": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "prefixItems": [
+        {"$ref": "#/$defs/scalarExpression"}                              ,
+        { "type": "array", "items": {"$ref": "#/$defs/scalarExpression"} }
+      ]
+    },
+    "isNullPredicate": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op"  : { "type": "string", "enum": ["isNull"] },
+        "args": {"$ref": "#/$defs/isNullOperand"}
+      }
+    },
+    "isNullOperand": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/characterExpression"},
+          {"$ref": "#/$defs/numericExpression"}  ,
+          {"$dynamicRef": "#cql2expression"}     ,
+          {"$ref": "#/$defs/spatialInstance"}    ,
+          {"$ref": "#/$defs/temporalInstance"}   ,
+          {"$ref": "#/$defs/propertyRef"}
+        ]
+      }
+    },
+    "spatialPredicate": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": {
+          "type": "string",
+          "enum": [
+            "s_contains"  , "s_crosses"   , "s_disjoint"  , "s_equals"    ,
+            "s_intersects", "s_overlaps"  , "s_touches"   , "s_within"
+          ]
+        },
+        "args": {"$ref": "#/$defs/spatialOperands"}
+      }
+    },
+    "spatialOperands": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/spatialInstance"},
+          {"$ref": "#/$defs/propertyRef"    },
+          {"$ref": "#/$defs/functionRef"    }
+        ]
+      }
+    },
+    "temporalPredicate": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": {
+          "type": "string",
+          "enum": [
+            "t_after"       , "t_before"      , "t_contains"    ,
+            "t_disjoint"    , "t_during"      , "t_equals"      ,
+            "t_finishedBy"  , "t_finishes"    , "t_intersects"  ,
+            "t_meets"       , "t_metBy"       , "t_overlappedBy",
+            "t_overlaps"    , "t_startedBy"   , "t_starts"
+          ]
+        },
+        "args": {"$ref": "#/$defs/temporalOperands"}
+      }
+    },
+    "temporalOperands": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/temporalInstance"},
+          {"$ref": "#/$defs/propertyRef"     },
+          {"$ref": "#/$defs/functionRef"     }
+        ]
+      }
+    },
+    "arrayPredicate": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": {
+          "type": "string",
+          "enum": ["a_containedBy", "a_contains", "a_equals", "a_overlaps"]
+        },
+        "args": {"$ref": "#/$defs/arrayExpression"}
+      }
+    },
+    "arrayExpression": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/array"      },
+          {"$ref": "#/$defs/propertyRef"},
+          {"$ref": "#/$defs/functionRef"}
+        ]
+      }
+    },
+    "array": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/characterExpression"},
+          {"$ref": "#/$defs/numericExpression"}  ,
+          {"$dynamicRef": "#cql2expression"}     ,
+          {"$ref": "#/$defs/spatialInstance"}    ,
+          {"$ref": "#/$defs/temporalInstance"}   ,
+          {"$ref": "#/$defs/array"}              ,
+          {"$ref": "#/$defs/propertyRef"}
+        ]
+      }
+    },
+    "arithmeticExpression": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": {
+          "type": "string",
+          "enum": ["+", "-", "*", "/", "^", "%", "div"]
+        },
+        "args": {"$ref": "#/$defs/arithmeticOperands"}
+      }
+    },
+    "arithmeticOperands": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/arithmeticExpression"                  },
+          {"$ref": "#/$defs/propertyRef"                           },
+          {"$ref": "#/$defs/functionRef"                           },
+          {                                        "type": "number"}
+        ]
+      }
+    },
+    "propertyRef": {
+      "type": "object",
+      "required": ["property"],
+      "properties": { "property": {"type": "string"} }
+    },
+    "casei": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": { "type": "string", "enum": ["casei"] },
+        "args": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"$ref": "#/$defs/characterExpression"},
+              {"$ref": "#/$defs/propertyRef"        },
+              {"$ref": "#/$defs/functionRef"        }
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 1
+        }
+      }
+    },
+    "accenti": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": { "type": "string", "enum": ["accenti"] },
+        "args": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"$ref": "#/$defs/characterExpression"},
+              {"$ref": "#/$defs/propertyRef"        },
+              {"$ref": "#/$defs/functionRef"        }
+            ]
+          },
+          "minItems": 1,
+          "maxItems": 1
+        }
+      }
+    },
+    "characterExpression": {
+      "oneOf": [
+        {"$ref": "#/$defs/casei"                    },
+        {"$ref": "#/$defs/accenti"                  },
+        {                           "type": "string"}
+      ]
+    },
+    "functionRef": {
+      "type": "object",
+      "required": ["op", "args"],
+      "properties": {
+        "op": {
+          "type": "string",
+          "not": {
+            "enum": [
+              "and"           , "or"            , "not"           ,
+              "="             , "<>"            , "<"             ,
+              ">"             , "<="            , ">="            ,
+              "like"          , "between"       , "in"            ,
+              "isNull"        , "casei"         , "accenti"       ,
+              "s_contains"    , "s_crosses"     , "s_disjoint"    ,
+              "s_equals"      , "s_intersects"  , "s_overlaps"    ,
+              "s_touches"     , "s_within"      , "t_after"       ,
+              "t_before"      , "t_contains"    , "t_disjoint"    ,
+              "t_during"      , "t_equals"      , "t_finishedBy"  ,
+              "t_finishes"    , "t_intersects"  , "t_meets"       ,
+              "t_metBy"       , "t_overlappedBy", "t_overlaps"    ,
+              "t_startedBy"   , "t_starts"      , "a_containedBy" ,
+              "a_contains"    , "a_equals"      , "a_overlaps"    ,
+              "+"             , "-"             , "*"             ,
+              "/"             , "^"             , "%"             ,
+              "div"
+            ]
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"$ref": "#/$defs/characterExpression"},
+              {"$ref": "#/$defs/numericExpression"}  ,
+              {"$dynamicRef": "#cql2expression"}     ,
+              {"$ref": "#/$defs/spatialInstance"}    ,
+              {"$ref": "#/$defs/temporalInstance"}   ,
+              {"$ref": "#/$defs/array"}              ,
+              {"$ref": "#/$defs/propertyRef"}
+            ]
+          }
+        }
+      }
+    },
+    "spatialInstance": {
+      "oneOf": [
+        {"$ref": "#/$defs/geometryLiteral"},
+        {"$ref": "#/$defs/bboxLiteral"    }
+      ]
+    },
+    "geometryLiteral": {
+      "oneOf": [
+        {"$ref": "#/$defs/point"             },
+        {"$ref": "#/$defs/linestring"        },
+        {"$ref": "#/$defs/polygon"           },
+        {"$ref": "#/$defs/multipoint"        },
+        {"$ref": "#/$defs/multilinestring"   },
+        {"$ref": "#/$defs/multipolygon"      },
+        {"$ref": "#/$defs/geometrycollection"}
+      ]
+    },
+    "point": {
+      "title": "GeoJSON Point",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": { "type": "string", "enum": ["Point"] },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": {"type": "number"}
+        },
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
+      }
+    },
+    "linestring": {
+      "title": "GeoJSON LineString",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": { "type": "string", "enum": ["LineString"] },
+        "coordinates": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "items": {"type": "number"}
+          }
+        },
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
+      }
+    },
+    "polygon": {
+      "title": "GeoJSON Polygon",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": { "type": "string", "enum": ["Polygon"] },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {"type": "number"}
+            }
+          }
+        },
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
+      }
+    },
+    "multipoint": {
+      "title": "GeoJSON MultiPoint",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": { "type": "string", "enum": ["MultiPoint"] },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "items": {"type": "number"}
+          }
+        },
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
+      }
+    },
+    "multilinestring": {
+      "title": "GeoJSON MultiLineString",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": { "type": "string", "enum": ["MultiLineString"] },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {"type": "number"}
+            }
+          }
+        },
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
+      }
+    },
+    "multipolygon": {
+      "title": "GeoJSON MultiPolygon",
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": { "type": "string", "enum": ["MultiPolygon"] },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": {"type": "number"}
+              }
+            }
+          }
+        },
+        "bbox": { "type": "array", "minItems": 4, "items": {"type": "number"} }
+      }
+    },
+    "geometrycollection": {
+      "title": "GeoJSON GeometryCollection",
+      "type": "object",
+      "required": ["type", "geometries"],
+      "properties": {
+        "type": { "type": "string", "enum": ["GeometryCollection"] },
+        "geometries": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "oneOf": [
+              {"$ref": "#/$defs/point"          },
+              {"$ref": "#/$defs/linestring"     },
+              {"$ref": "#/$defs/polygon"        },
+              {"$ref": "#/$defs/multipoint"     },
+              {"$ref": "#/$defs/multilinestring"},
+              {"$ref": "#/$defs/multipolygon"   }
+            ]
+          }
+        }
+      }
+    },
+    "bboxLiteral": {
+      "type": "object",
+      "required": ["bbox"],
+      "properties": { "bbox": {"$ref": "#/$defs/bbox"} }
+    },
+    "bbox": {
+      "type": "array",
+      "oneOf": [
+        {"minItems": 4, "maxItems": 4},
+        {"minItems": 6, "maxItems": 6}
+      ],
+      "items": {"type": "number"}
+    },
+    "temporalInstance": {
+      "oneOf": [
+        {"$ref": "#/$defs/instantInstance" },
+        {"$ref": "#/$defs/intervalInstance"}
+      ]
+    },
+    "instantInstance": {
+      "oneOf": [
+        {"$ref": "#/$defs/dateInstant"     },
+        {"$ref": "#/$defs/timestampInstant"}
+      ]
+    },
+    "dateInstant": {
+      "type": "object",
+      "required": ["date"],
+      "properties": { "date": {"$ref": "#/$defs/dateString"} }
+    },
+    "timestampInstant": {
+      "type": "object",
+      "required": ["timestamp"],
+      "properties": { "timestamp": {"$ref": "#/$defs/timestampString"} }
+    },
+    "instantString": {
+      "oneOf": [
+        {"$ref": "#/$defs/dateString"     },
+        {"$ref": "#/$defs/timestampString"}
+      ]
+    },
+    "dateString": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
+    "timestampString": {
+      "type"   : "string"                                                  ,
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    },
+    "intervalInstance": {
+      "type": "object",
+      "required": ["interval"],
+      "properties": { "interval": {"$ref": "#/$defs/intervalArray"} }
+    },
+    "intervalArray": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "oneOf": [
+          {"$ref": "#/$defs/instantString"}   ,
+          { "type": "string", "enum": [".."] },
+          {"$ref": "#/$defs/propertyRef"}     ,
+          {"$ref": "#/$defs/functionRef"}
+        ]
+      }
+    }
+  }
+}

--- a/filter/testdata/schema/readme.md
+++ b/filter/testdata/schema/readme.md
@@ -1,0 +1,3 @@
+Schema files used for validation:
+
+ * cql2.json - https://github.com/opengeospatial/ogcapi-features/blob/e262e17f8da169f23ebc0c793ad217d6ccaada5b/cql2/standard/schema/cql2.json

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rK
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This updates a number of things to deal with changes in the spec.  Most of these changes came in https://github.com/opengeospatial/ogcapi-features/pull/831

Breaking changes include:

 * Previously, all "user defined" functions were in an object like this `{"function": {"name": "custom"}}`.  Now, these are collapsed into the existing built-in "op" expressions.  So `{"op": "custom", args: []}` is the equivalent (args are required).

 * Previously, case insensitive and accent insensitive expressions were in `{"casei": "Foo"}` and `{"accenti": "bǎr"}` type expressions.  Now these are collapsed into the existing built-in "op" expressions.  So `{"op": "casei", "args": ["Foo"]}` and `{"op": "accenti", "args": ["bǎr"]}`.

Another change here is that interval arrays are string literals instead of date/timestamp objects.  This was either my misreading the spec previously or another change.

I've added validation for all JSON output using the latest [CQL2 JSON Schema](https://github.com/opengeospatial/ogcapi-features/blob/e262e17f8da169f23ebc0c793ad217d6ccaada5b/cql2/standard/schema/cql2.json).

This should be more stable now since voting on the spec is underway.

Fixes #62.

