### PR TITLE
Add string representation for expressions

### DIFF
--- a/filter/array.go
+++ b/filter/array.go
@@ -47,6 +47,10 @@ func (e *ArrayComparison) MarshalJSON() ([]byte, error) {
 	return marshalOp(e.Name, args)
 }
 
+func (e *ArrayComparison) String() string {
+	return toString(e)
+}
+
 type ArrayItemExpression interface {
 	Expression
 	arrayItemExpression()
@@ -83,4 +87,8 @@ func decodeArray(values []any) (Array, error) {
 		items[i] = item
 	}
 	return items, nil
+}
+
+func (a Array) String() string {
+	return sliceToString(a)
 }

--- a/filter/array_test.go
+++ b/filter/array_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestArrayComparison(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.ArrayComparison{
@@ -92,22 +86,9 @@ func TestArrayComparison(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.NoError(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.NoError(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/boolean.go
+++ b/filter/boolean.go
@@ -45,3 +45,10 @@ func (e *Boolean) MarshalJSON() ([]byte, error) {
 	}
 	return []byte("false"), nil
 }
+
+func (e *Boolean) String() string {
+	if e.Value {
+		return "true"
+	}
+	return "false"
+}

--- a/filter/boolean_test.go
+++ b/filter/boolean_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBoolean(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Boolean{true},
@@ -43,22 +37,9 @@ func TestBoolean(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.Nil(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			var v bool
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.Nil(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/character.go
+++ b/filter/character.go
@@ -58,6 +58,10 @@ func (e *CaseInsensitive) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+func (e *CaseInsensitive) String() string {
+	return toString(e)
+}
+
 type AccentInsensitive struct {
 	Value CharacterExpression
 }
@@ -83,6 +87,10 @@ func (e *AccentInsensitive) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
+func (e *AccentInsensitive) String() string {
+	return toString(e)
+}
+
 type String struct {
 	Value string
 }
@@ -103,4 +111,8 @@ func (*String) arrayItemExpression() {}
 
 func (e *String) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.Value)
+}
+
+func (e *String) String() string {
+	return toString(e)
 }

--- a/filter/character_test.go
+++ b/filter/character_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCharacter(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Comparison{
@@ -70,22 +64,9 @@ func TestCharacter(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.Nil(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.Nil(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/comparison.go
+++ b/filter/comparison.go
@@ -50,8 +50,12 @@ func (e *Comparison) MarshalJSON() ([]byte, error) {
 	return marshalOp(e.Name, args)
 }
 
+func (e *Comparison) String() string {
+	return toString(e)
+}
+
 type Like struct {
-	String  CharacterExpression
+	Value   CharacterExpression
 	Pattern PatternExpression
 }
 
@@ -66,8 +70,12 @@ func (*Like) scalarExpression()  {}
 func (*Like) booleanExpression() {}
 
 func (e *Like) MarshalJSON() ([]byte, error) {
-	args := []Expression{e.String, e.Pattern}
+	args := []Expression{e.Value, e.Pattern}
 	return marshalOp(likeOp, args)
+}
+
+func (e *Like) String() string {
+	return toString(e)
 }
 
 type Between struct {
@@ -91,6 +99,10 @@ func (e *Between) MarshalJSON() ([]byte, error) {
 	return marshalOp(betweenOp, args)
 }
 
+func (e *Between) String() string {
+	return toString(e)
+}
+
 type ScalarList []ScalarExpression
 
 var (
@@ -99,6 +111,10 @@ var (
 
 func (ScalarList) expression()       {}
 func (ScalarList) scalarExpression() {}
+
+func (e ScalarList) String() string {
+	return sliceToString(e)
+}
 
 type In struct {
 	Item ScalarExpression
@@ -120,6 +136,10 @@ func (e *In) MarshalJSON() ([]byte, error) {
 	return marshalOp(inOp, args)
 }
 
+func (e *In) String() string {
+	return toString(e)
+}
+
 type IsNull struct {
 	Value Expression
 }
@@ -137,4 +157,8 @@ func (*IsNull) booleanExpression() {}
 func (e *IsNull) MarshalJSON() ([]byte, error) {
 	args := []Expression{e.Value}
 	return marshalOp(isNullOp, args)
+}
+
+func (e *IsNull) String() string {
+	return toString(e)
 }

--- a/filter/comparison_test.go
+++ b/filter/comparison_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestComparison(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Comparison{
@@ -123,7 +117,7 @@ func TestComparison(t *testing.T) {
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Like{
-					String:  &filter.Property{"name"},
+					Value:   &filter.Property{"name"},
 					Pattern: &filter.CaseInsensitive{&filter.String{"park"}},
 				},
 			},
@@ -135,7 +129,7 @@ func TestComparison(t *testing.T) {
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Like{
-					String:  &filter.Property{"name"},
+					Value:   &filter.Property{"name"},
 					Pattern: &filter.AccentInsensitive{&filter.String{"Noël"}},
 				},
 			},
@@ -183,22 +177,9 @@ func TestComparison(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.NoError(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.NoError(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/expression.go
+++ b/filter/expression.go
@@ -22,6 +22,7 @@ import (
 
 type Expression interface {
 	expression()
+	String() string
 }
 
 type ScalarExpression interface {

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -52,3 +52,7 @@ func (f *Filter) UnmarshalJSON(data []byte) error {
 	f.Expression = booleanExpression
 	return nil
 }
+
+func (e *Filter) String() string {
+	return toString(e)
+}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -1,19 +1,53 @@
 package filter_test
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
+	"github.com/planetlabs/go-ogc/filter"
 	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+var cachedSchema *jsonschema.Schema
+
 func getSchema(t *testing.T) *jsonschema.Schema {
+	if cachedSchema != nil {
+		return cachedSchema
+	}
 	schemaData, err := os.ReadFile("testdata/schema/cql2.json")
 	require.NoError(t, err)
 
 	schema, err := jsonschema.CompileString("cql2.json", string(schemaData))
 	require.NoError(t, err)
 
+	cachedSchema = schema
 	return schema
+}
+
+type FilterCase struct {
+	filter *filter.Filter
+	data   string
+}
+
+func assertFilterIO(t *testing.T, c *FilterCase) {
+	schema := getSchema(t)
+
+	data, err := json.Marshal(c.filter)
+	require.NoError(t, err)
+	assert.JSONEq(t, c.data, string(data))
+
+	var v any
+	require.NoError(t, json.Unmarshal(data, &v))
+	if err := schema.Validate(v); err != nil {
+		t.Errorf("failed to validate\n%#v", err)
+	}
+
+	filter := &filter.Filter{}
+	require.NoError(t, json.Unmarshal([]byte(c.data), filter))
+	assert.Equal(t, c.filter, filter)
+
+	assert.JSONEq(t, c.data, c.filter.String())
 }

--- a/filter/function.go
+++ b/filter/function.go
@@ -53,3 +53,7 @@ func (e *Function) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(f)
 }
+
+func (e *Function) String() string {
+	return toString(e)
+}

--- a/filter/function_test.go
+++ b/filter/function_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFunction(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Comparison{
@@ -64,22 +58,9 @@ func TestFunction(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.Nil(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.Nil(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/logical.go
+++ b/filter/logical.go
@@ -43,6 +43,10 @@ func (e *Not) MarshalJSON() ([]byte, error) {
 	return marshalOp(notOp, args)
 }
 
+func (e *Not) String() string {
+	return toString(e)
+}
+
 type And struct {
 	Args []BooleanExpression
 }
@@ -65,6 +69,10 @@ func (e *And) MarshalJSON() ([]byte, error) {
 	return marshalOp(andOp, args)
 }
 
+func (e *And) String() string {
+	return toString(e)
+}
+
 type Or struct {
 	Args []BooleanExpression
 }
@@ -85,4 +93,8 @@ func (e *Or) MarshalJSON() ([]byte, error) {
 		args[i] = arg
 	}
 	return marshalOp(orOp, args)
+}
+
+func (e *Or) String() string {
+	return toString(e)
 }

--- a/filter/logical_test.go
+++ b/filter/logical_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLogical(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Not{
@@ -95,22 +89,9 @@ func TestLogical(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.Nil(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.Nil(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/numeric.go
+++ b/filter/numeric.go
@@ -40,3 +40,7 @@ func (*Number) arrayItemExpression() {}
 func (e *Number) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.Value)
 }
+
+func (e *Number) String() string {
+	return toString(e)
+}

--- a/filter/numeric_test.go
+++ b/filter/numeric_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNumeric(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Comparison{
@@ -44,22 +38,9 @@ func TestNumeric(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.Nil(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.Nil(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/op.go
+++ b/filter/op.go
@@ -35,6 +35,27 @@ func marshalOp(name string, args []Expression) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+func toString(e json.Marshaler) string {
+	v, err := e.MarshalJSON()
+	if err != nil {
+		return fmt.Sprintf("%#v", e)
+	}
+	return string(v)
+}
+
+func sliceToString[T Expression](e []T) string {
+	buffer := &bytes.Buffer{}
+	buffer.WriteString("[")
+	for i, item := range e {
+		if i > 0 {
+			buffer.WriteString(", ")
+		}
+		buffer.WriteString(item.String())
+	}
+	buffer.WriteString("]")
+	return buffer.String()
+}
+
 var argCount = map[string]int{
 	notOp:               1,
 	likeOp:              2,
@@ -129,7 +150,7 @@ func decodeOp(name string, encodedArgs []any) (Expression, error) {
 		if !ok {
 			return nil, fmt.Errorf("expected a pattern expression for arg 1 of %q op", name)
 		}
-		return &Like{String: str, Pattern: pattern}, nil
+		return &Like{Value: str, Pattern: pattern}, nil
 
 	case betweenOp:
 		numericArgs, err := toNumericArgs(name, args)

--- a/filter/property.go
+++ b/filter/property.go
@@ -43,3 +43,7 @@ func (*Property) temporalExpression()  {}
 func (e *Property) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{"property": e.Name})
 }
+
+func (e *Property) String() string {
+	return toString(e)
+}

--- a/filter/property_test.go
+++ b/filter/property_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestProperty(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Comparison{
@@ -44,22 +38,9 @@ func TestProperty(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.NoError(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.NoError(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/spatial.go
+++ b/filter/spatial.go
@@ -52,6 +52,10 @@ func (e *SpatialComparison) MarshalJSON() ([]byte, error) {
 	return marshalOp(e.Name, args)
 }
 
+func (e *SpatialComparison) String() string {
+	return toString(e)
+}
+
 type SpatialExpression interface {
 	Expression
 	spatialExpression()
@@ -74,6 +78,10 @@ func (*Geometry) arrayItemExpression() {}
 
 func (e *Geometry) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.Value)
+}
+
+func (e *Geometry) String() string {
+	return toString(e)
 }
 
 var geometryTypes = map[string]bool{
@@ -126,6 +134,10 @@ func (*BoundingBox) arrayItemExpression() {}
 
 func (e *BoundingBox) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string][]float64{"bbox": e.Extent})
+}
+
+func (e *BoundingBox) String() string {
+	return toString(e)
 }
 
 func decodeBoundingBox(bbox []any) (*BoundingBox, error) {

--- a/filter/spatial_test.go
+++ b/filter/spatial_test.go
@@ -15,20 +15,14 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSpatial(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.SpatialComparison{
@@ -159,22 +153,9 @@ func TestSpatial(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.NoError(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.NoError(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }

--- a/filter/temporal.go
+++ b/filter/temporal.go
@@ -61,6 +61,10 @@ func (e *TemporalComparison) MarshalJSON() ([]byte, error) {
 	return marshalOp(e.Name, args)
 }
 
+func (e *TemporalComparison) String() string {
+	return toString(e)
+}
+
 type TemporalExpression interface {
 	Expression
 	temporalExpression()
@@ -90,6 +94,10 @@ func (e *Date) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{"date": e.Value.Format(time.DateOnly)})
 }
 
+func (e *Date) String() string {
+	return toString(e)
+}
+
 func decodeDate(value string) (*Date, error) {
 	date, err := time.Parse(time.DateOnly, value)
 	if err != nil {
@@ -115,6 +123,10 @@ func (*Timestamp) temporalExpression() {}
 
 func (e *Timestamp) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{"timestamp": e.Value.Format(time.RFC3339Nano)})
+}
+
+func (e *Timestamp) String() string {
+	return toString(e)
 }
 
 func decodeTimestamp(value string) (*Timestamp, error) {
@@ -173,6 +185,10 @@ func (e *Interval) MarshalJSON() ([]byte, error) {
 		}
 	}
 	return json.Marshal(map[string]any{"interval": items})
+}
+
+func (e *Interval) String() string {
+	return toString(e)
 }
 
 const nilInstant = ".."

--- a/filter/temporal_test.go
+++ b/filter/temporal_test.go
@@ -15,21 +15,15 @@
 package filter_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/planetlabs/go-ogc/filter"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTemporal(t *testing.T) {
-	cases := []struct {
-		filter *filter.Filter
-		data   string
-	}{
+	cases := []*FilterCase{
 		{
 			filter: &filter.Filter{
 				Expression: &filter.Comparison{
@@ -401,22 +395,9 @@ func TestTemporal(t *testing.T) {
 		},
 	}
 
-	schema := getSchema(t)
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			data, err := json.Marshal(c.filter)
-			require.NoError(t, err)
-			assert.JSONEq(t, c.data, string(data))
-
-			v := map[string]any{}
-			require.NoError(t, json.Unmarshal(data, &v))
-			if err := schema.Validate(v); err != nil {
-				t.Errorf("failed to validate\n%#v", err)
-			}
-
-			filter := &filter.Filter{}
-			require.NoError(t, json.Unmarshal([]byte(c.data), filter))
-			assert.Equal(t, c.filter, filter)
+			assertFilterIO(t, c)
 		})
 	}
 }


### PR DESCRIPTION
This adds a `e.String()` method to filter expressions.

This is a breaking change for the `filter.Like` struct where the `String` field has been renamed to `Value` to allow for the new `String` method.